### PR TITLE
running-from-git: Little tweak for Arch instructions

### DIFF
--- a/documentation/running-from-git.mdwn
+++ b/documentation/running-from-git.mdwn
@@ -43,11 +43,10 @@ Download the PKGBUILD, run [makepkg][] and install the resulting package with
 pacman, using the following commands:
 
     mkdir -p ~/builds; cd ~/builds
-    wget http://aur.archlinux.org/packages/sm/smuxi-git/smuxi-git.tar.gz
+    wget https://aur.archlinux.org/packages/sm/smuxi-git/smuxi-git.tar.gz
     tar -xaf smuxi-git.tar.gz
     cd smuxi-git
-    makepkg -s
-    su -c "pacman -U smuxi-git-*.tar.xz"
+    makepkg -si
 
 To follow other branches (like stable) append the source line in the PKGBUILD
 with #branch=&lt;branchname&gt; e.g.:


### PR DESCRIPTION
makepkg has an option that allows to install the created packages on a successful build: -i, --install
Simpler and less likely to fail.

And change the download url from http to https
__________
One additional note. Since I switched to a Split-PKGBuild the pacman -U command would only install the frontend package and ignore the new server package, due to their names (smuxi-git and smuxi-server-git). So it's the best to relegate the installation to makepkg